### PR TITLE
Added ability to read downstream and upstream channels

### DIFF
--- a/connect_box/__init__.py
+++ b/connect_box/__init__.py
@@ -17,7 +17,8 @@ HTTP_HEADER_X_REQUESTED_WITH = "X-Requested-With"
 
 CMD_LOGIN = 15
 CMD_DEVICES = 123
-
+CMD_DOWNSTREAM = 10
+CMD_UPSTREAM = 11
 
 @attr.s
 class Device:
@@ -27,6 +28,37 @@ class Device:
     hostname: str = attr.ib(cmp=False)
     ip: Union[IPv4Address, IPv6Address] = attr.ib(cmp=False, factory=convert_ip)
 
+@attr.s
+class DownstreamChannel:
+    """A locked downstream channel."""
+
+    frequency: int = attr.ib()
+    powerLevel: int = attr.ib()
+    modulation: str = attr.ib()
+    id: str = attr.ib()
+    snr: float = attr.ib()
+    preRs: int = attr.ib()
+    postRs: int = attr.ib()
+    qamLocked: bool = attr.ib()
+    fecLocked: bool = attr.ib()
+    mpegLocked: bool = attr.ib()
+
+@attr.s
+class UpstreamChannel:
+    """A locked upstream channel."""
+
+    frequency: int = attr.ib()
+    powerLevel: int = attr.ib()
+    symbolRate: str = attr.ib()
+    id: str = attr.ib()
+    modulation: str = attr.ib()
+    type: str = attr.ib()
+    t1Timeouts: int = attr.ib()
+    t2Timeouts: int = attr.ib()
+    t3Timeouts: int = attr.ib()
+    t4Timeouts: int = attr.ib()
+    channelType: str = attr.ib()
+    messageType: int = attr.ib()
 
 class ConnectBox:
     """A class for handling the data retrieval from an UPC Connect Box ."""
@@ -49,6 +81,8 @@ class ConnectBox:
             ),
         }
         self.devices: List[Device] = []
+        self.ds_channels: List[DownstreamChannel] = []
+        self.us_channels: List[UpstreamChannel] = []
 
     async def async_get_devices(self) -> List[Device]:
         """Scan for new devices and return a list with found device IDs."""
@@ -74,7 +108,65 @@ class ConnectBox:
             self.token = None
             raise exceptions.ConnectBoxNoDataAvailable() from None
 
-        return self.devices
+    async def async_get_downstream(self):
+        """Get the current downstream cable modem state."""
+
+        if self.token is None:
+            await self.async_initialize_token()
+
+        raw = await self._async_ws_function(CMD_DOWNSTREAM)
+
+        try:
+            xml_root = element_tree.fromstring(raw)
+            self.ds_channels.clear()
+            for ds in xml_root.iter('downstream'):
+                self.ds_channels.append(DownstreamChannel(
+                    int(ds.find('freq').text),
+                    int(ds.find('pow').text),
+                    ds.find('mod').text,
+                    ds.find('chid').text,
+                    float(ds.find('RxMER').text),
+                    int(ds.find('PreRs').text),
+                    int(ds.find('PostRs').text),
+                    ds.find('IsQamLocked').text == '1',
+                    ds.find('IsFECLocked').text == '1',
+                    ds.find('IsMpegLocked').text == '1'
+                ))
+        except (element_tree.ParseError, TypeError):
+            _LOGGER.warning("Can't read downstream channels from %s", self.host)
+            self.token = None
+            raise exceptions.ConnectBoxNoDataAvailable() from None
+
+    async def async_get_upstream(self):
+        """Get the current upstream cable modem state."""
+
+        if self.token is None:
+            await self.async_initialize_token()
+
+        raw = await self._async_ws_function(CMD_UPSTREAM)
+
+        try:
+            xml_root = element_tree.fromstring(raw)
+            self.us_channels.clear()
+            for us in xml_root.iter('upstream'):
+                self.us_channels.append(UpstreamChannel(
+                    int(us.find('freq').text),
+                    int(us.find('power').text),
+                    us.find('srate').text,
+                    us.find('usid').text,
+                    us.find('mod').text,
+                    us.find('ustype').text,
+                    int(us.find('t1Timeouts').text),
+                    int(us.find('t2Timeouts').text),
+                    int(us.find('t3Timeouts').text),
+                    int(us.find('t4Timeouts').text),
+                    us.find('channeltype').text,
+                    int(us.find('messageType').text),
+                ))
+        except (element_tree.ParseError, TypeError):
+            _LOGGER.warning("Can't read upstream channels from %s", self.host)
+            self.token = None
+            raise exceptions.ConnectBoxNoDataAvailable() from None
 
     async def async_initialize_token(self) -> bool:
         """Get the token first."""

--- a/connect_box/__init__.py
+++ b/connect_box/__init__.py
@@ -20,6 +20,7 @@ CMD_DEVICES = 123
 CMD_DOWNSTREAM = 10
 CMD_UPSTREAM = 11
 
+
 @attr.s
 class Device:
     """A single device."""
@@ -27,6 +28,7 @@ class Device:
     mac: str = attr.ib()
     hostname: str = attr.ib(cmp=False)
     ip: Union[IPv4Address, IPv6Address] = attr.ib(cmp=False, factory=convert_ip)
+
 
 @attr.s
 class DownstreamChannel:
@@ -42,6 +44,7 @@ class DownstreamChannel:
     qamLocked: bool = attr.ib()
     fecLocked: bool = attr.ib()
     mpegLocked: bool = attr.ib()
+
 
 @attr.s
 class UpstreamChannel:
@@ -59,6 +62,7 @@ class UpstreamChannel:
     t4Timeouts: int = attr.ib()
     channelType: str = attr.ib()
     messageType: int = attr.ib()
+
 
 class ConnectBox:
     """A class for handling the data retrieval from an UPC Connect Box ."""
@@ -119,19 +123,21 @@ class ConnectBox:
         try:
             xml_root = element_tree.fromstring(raw)
             self.ds_channels.clear()
-            for ds in xml_root.iter('downstream'):
-                self.ds_channels.append(DownstreamChannel(
-                    int(ds.find('freq').text),
-                    int(ds.find('pow').text),
-                    ds.find('mod').text,
-                    ds.find('chid').text,
-                    float(ds.find('RxMER').text),
-                    int(ds.find('PreRs').text),
-                    int(ds.find('PostRs').text),
-                    ds.find('IsQamLocked').text == '1',
-                    ds.find('IsFECLocked').text == '1',
-                    ds.find('IsMpegLocked').text == '1'
-                ))
+            for downstream in xml_root.iter("downstream"):
+                self.ds_channels.append(
+                    DownstreamChannel(
+                        int(downstream.find("freq").text),
+                        int(downstream.find("pow").text),
+                        downstream.find("mod").text,
+                        downstream.find("chid").text,
+                        float(downstream.find("RxMER").text),
+                        int(downstream.find("PreRs").text),
+                        int(downstream.find("PostRs").text),
+                        downstream.find("IsQamLocked").text == "1",
+                        downstream.find("IsFECLocked").text == "1",
+                        downstream.find("IsMpegLocked").text == "1",
+                    )
+                )
         except (element_tree.ParseError, TypeError):
             _LOGGER.warning("Can't read downstream channels from %s", self.host)
             self.token = None
@@ -148,21 +154,23 @@ class ConnectBox:
         try:
             xml_root = element_tree.fromstring(raw)
             self.us_channels.clear()
-            for us in xml_root.iter('upstream'):
-                self.us_channels.append(UpstreamChannel(
-                    int(us.find('freq').text),
-                    int(us.find('power').text),
-                    us.find('srate').text,
-                    us.find('usid').text,
-                    us.find('mod').text,
-                    us.find('ustype').text,
-                    int(us.find('t1Timeouts').text),
-                    int(us.find('t2Timeouts').text),
-                    int(us.find('t3Timeouts').text),
-                    int(us.find('t4Timeouts').text),
-                    us.find('channeltype').text,
-                    int(us.find('messageType').text),
-                ))
+            for upstream in xml_root.iter("upstream"):
+                self.us_channels.append(
+                    UpstreamChannel(
+                        int(upstream.find("freq").text),
+                        int(upstream.find("power").text),
+                        upstream.find("srate").text,
+                        upstream.find("usid").text,
+                        upstream.find("mod").text,
+                        upstream.find("ustype").text,
+                        int(upstream.find("t1Timeouts").text),
+                        int(upstream.find("t2Timeouts").text),
+                        int(upstream.find("t3Timeouts").text),
+                        int(upstream.find("t4Timeouts").text),
+                        upstream.find("channeltype").text,
+                        int(upstream.find("messageType").text),
+                    )
+                )
         except (element_tree.ParseError, TypeError):
             _LOGGER.warning("Can't read upstream channels from %s", self.host)
             self.token = None

--- a/example.py
+++ b/example.py
@@ -1,5 +1,6 @@
 """Get the data from an UPC Connect Box."""
 import asyncio
+from pprint import pprint
 
 import aiohttp
 
@@ -11,9 +12,17 @@ async def main():
     async with aiohttp.ClientSession() as session:
         client = ConnectBox(session, "password")
 
+        # Print details about the downstream channel connectivity
+        await client.async_get_downstream()
+        pprint(client.ds_channels)
+
+        # Print details about the upstream channel connectivity
+        await client.async_get_upstream()
+        pprint(client.us_channels)
+
         # Print details about the connected devices
         await client.async_get_devices()
-        print(client.devices)
+        pprint(client.devices)
 
 
 loop = asyncio.get_event_loop()


### PR DESCRIPTION
Thanks for this project, this saved me a lot of time in figuring out how to get stats from the box :)

Since I've had packet loss (25%+) that were intermittent, I wanted to read error rates from the box and graph them in Grafana, so I extended your lib with reading the upstream/downstream tabs of the ConnectBox interface.

Maybe you'll also find this useful and want to integrate it your project.