### PR TITLE
Add upc_connect passwort authentication

### DIFF
--- a/example.py
+++ b/example.py
@@ -9,7 +9,7 @@ from connect_box import ConnectBox
 async def main():
     """Sample code to retrieve the data from an UPC Connect Box."""
     async with aiohttp.ClientSession() as session:
-        client = ConnectBox(loop, session)
+        client = ConnectBox(loop, session, "password")
 
         # Print details about the connected devices
         await client.async_get_devices()


### PR DESCRIPTION
UPC connect component seems to have upgraded and required a password authentication retrieve the connected devices. This was not necessary before the upgrade of the UPC connect box.