### PR TITLE
Ipv6 filters

### DIFF
--- a/connect_box/__init__.py
+++ b/connect_box/__init__.py
@@ -267,7 +267,7 @@ class ConnectBox:
         self.cmstatus = None
         self.downstream_service_flows = []
         self.upstream_service_flows = []
-        raw = await self._async_ws_function(CMD_CMSTATUS)
+        raw = await self._async_ws_get_function(CMD_CMSTATUS)
 
         try:
             xml_root = element_tree.fromstring(raw)
@@ -314,7 +314,7 @@ class ConnectBox:
             await self.async_initialize_token()
 
         self.temperature = None
-        raw = await self._async_ws_function(CMD_TEMPERATURE)
+        raw = await self._async_ws_get_function(CMD_TEMPERATURE)
 
         f_to_c = lambda f: (5.0 / 9) * (f - 32)
         try:

--- a/connect_box/__init__.py
+++ b/connect_box/__init__.py
@@ -2,13 +2,18 @@
 import asyncio
 import logging
 from typing import Dict, List, Optional
+from collections import OrderedDict
 
+import attr
 import aiohttp
 from aiohttp.hdrs import REFERER, USER_AGENT
 import defusedxml.ElementTree as element_tree
 
-from .data import Device, DownstreamChannel, UpstreamChannel
+from .data import Device, DownstreamChannel, UpstreamChannel, \
+    Ipv6FilterInstance, FilterState, FilterStatesList, FiltersTimeMode
+from .parsers import _parse_general_time, _parse_daily_time
 from . import exceptions
+
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -19,6 +24,8 @@ CMD_LOGOUT = 16
 CMD_DEVICES = 123
 CMD_DOWNSTREAM = 10
 CMD_UPSTREAM = 11
+CMD_GET_IPV6_FILTER_RULE = 111
+CMD_SET_IPV6_FILTER_RULE = 112
 
 
 class ConnectBox:
@@ -44,6 +51,8 @@ class ConnectBox:
         self.devices: List[Device] = []
         self.ds_channels: List[DownstreamChannel] = []
         self.us_channels: List[UpstreamChannel] = []
+        self.ipv6_filters: List[Ipv6FilterInstance] = []
+        self._ipv6_filters_time: FiltersTimeMode = None
 
     async def async_get_devices(self) -> List[Device]:
         """Scan for new devices and return a list with found device IDs."""
@@ -51,7 +60,7 @@ class ConnectBox:
             await self.async_initialize_token()
 
         self.devices.clear()
-        raw = await self._async_ws_function(CMD_DEVICES)
+        raw = await self._async_ws_get_function(CMD_DEVICES)
 
         try:
             xml_root = element_tree.fromstring(raw)
@@ -76,7 +85,7 @@ class ConnectBox:
             await self.async_initialize_token()
 
         self.ds_channels.clear()
-        raw = await self._async_ws_function(CMD_DOWNSTREAM)
+        raw = await self._async_ws_get_function(CMD_DOWNSTREAM)
 
         try:
             xml_root = element_tree.fromstring(raw)
@@ -106,7 +115,7 @@ class ConnectBox:
             await self.async_initialize_token()
 
         self.us_channels.clear()
-        raw = await self._async_ws_function(CMD_UPSTREAM)
+        raw = await self._async_ws_get_function(CMD_UPSTREAM)
 
         try:
             xml_root = element_tree.fromstring(raw)
@@ -132,12 +141,112 @@ class ConnectBox:
             self.token = None
             raise exceptions.ConnectBoxNoDataAvailable() from None
 
+    async def async_get_ipv6_filtering(self) -> None:
+        """Get the current ipv6 filter (and filters time) rules."""
+        if self.token is None:
+            await self.async_initialize_token()
+
+        self.ipv6_filters.clear()
+        self._ipv6_filters_time = None
+        raw = await self._async_ws_get_function(CMD_GET_IPV6_FILTER_RULE)
+
+        try:
+            xml_root = element_tree.fromstring(raw)    
+            for instance in xml_root.iter("instance"):
+                self.ipv6_filters.append(
+                    Ipv6FilterInstance(
+                        int(instance.find("idd").text),
+                        instance.find("src_addr").text,
+                        int(instance.find("src_prefix").text),
+                        instance.find("dst_addr").text,
+                        int(instance.find("dst_prefix").text),
+                        int(instance.find("src_sport").text),
+                        int(instance.find("src_eport").text),
+                        int(instance.find("dst_sport").text),
+                        int(instance.find("dst_eport").text),
+                        int(instance.find("protocol").text),
+                        int(instance.find("allow").text),
+                        int(instance.find("enabled").text),
+                    )
+                )
+
+            self._ipv6_filters_time = FiltersTimeMode(
+                int(xml_root.find("time_mode").text),
+                _parse_general_time(xml_root),
+                _parse_daily_time(xml_root)
+            )
+    
+        except (element_tree.ParseError, TypeError):
+            _LOGGER.warning("Can't read IPv6 filter rules from %s", self.host)
+            self.token = None
+            raise exceptions.ConnectBoxNoDataAvailable() from None
+
+    async def _async_get_ipv6_filter_states(self) -> FilterStatesList:
+        """Get enable/disable states of IPv6 filter instances"""
+        await self.async_get_ipv6_filtering()
+        return FilterStatesList(list(FilterState(filter_instance.idd, filter_instance.enabled) for filter_instance in self.ipv6_filters))
+
+    async def _async_update_ipv6_filter_states(self, filter_states: FilterStatesList):
+        """Update enable/disable states of IPv6 filters while not affecting any other setting"""
+        if self.token is None:
+            await self.async_initialize_token()
+
+        val_enabled = '*'.join([str(fs.enabled) for fs in filter_states.entries])
+        val_del = '*'.join(['0' for fs in filter_states.entries])
+        val_idd = '*'.join([str(fs.idd) for fs in filter_states.entries])
+    
+        params = OrderedDict()
+        params['act'] = 1
+        params['dir'] = 0
+        params['enabled'] = val_enabled
+        params['allow_traffic'] = ''
+        params['protocol'] = ''
+        params['src_addr'] = ''
+        params['src_prefix'] = ''
+        params['dst_addr'] = ''
+        params['dst_prefix'] = ''
+        params['ssport'] = ''
+        params['seport'] = ''
+        params['dsport'] = ''
+        params['deport'] = ''
+        params['del'] = val_del
+        params['idd'] = val_idd
+        params['sIpRange'] = ''
+        params['dsIpRange'] = ''
+        params['PortRange'] = ''
+        params['TMode'] = self._ipv6_filters_time.TMode
+        if self._ipv6_filters_time.TMode == 1: 
+            params['TRule'] = self._ipv6_filters_time.XmlGeneralTime
+        elif self._ipv6_filters_time.TMode == 2: 
+            params['TRule'] = self._ipv6_filters_time.XmlDailyTime
+        else:
+            params['TRule'] = 0
+
+        await self._async_ws_set_function(CMD_SET_IPV6_FILTER_RULE, params)
+
+    async def async_toggle_ipv6_filter(self, idd: int) -> Optional[bool]:
+        """Toggle enable/disable of the filter with a given idd."""
+        states = await self._async_get_ipv6_filter_states()
+        new_value = None
+
+        for st in states.entries:
+            if st.idd == idd:
+                st.enabled = int(not(bool(st.enabled)))
+                new_value = bool(st.enabled)
+                break
+        if new_value is not None:
+            await self._async_update_ipv6_filter_states(states)
+            return new_value
+
+        _LOGGER.warning("Filter %d not found", idd)
+        return None
+
     async def async_close_session(self) -> None:
         """Logout and close session."""
         if not self.token:
             return
 
-        await self._async_ws_function(CMD_LOGOUT)
+        await self._async_ws_get_function(CMD_LOGOUT)
         self.token = None
 
     async def async_initialize_token(self) -> None:
@@ -180,7 +289,7 @@ class ConnectBox:
             _LOGGER.error("Can not login to %s: %s", self.host, err)
             raise exceptions.ConnectBoxConnectionError()
 
-    async def _async_ws_function(self, function: int) -> Optional[str]:
+    async def _async_ws_get_function(self, function: int) -> Optional[str]:
         """Execute a command on UPC firmware webservice."""
         try:
             # The 'token' parameter has to be first, and 'fun' second
@@ -202,6 +311,46 @@ class ConnectBox:
                 # Load data, store token for next request
                 self.token = response.cookies["sessionToken"].value
                 return await response.text()
+
+        except (asyncio.TimeoutError, aiohttp.ClientError) as err:
+            _LOGGER.error("Error received on %s: %s", function, err)
+            self.token = None
+
+        raise exceptions.ConnectBoxConnectionError()
+
+    async def _async_ws_set_function(self, function: int, params: dict) -> Optional[bool]:
+        """Execute a set command on UPC firmware webservice.
+
+        Args:
+            function(int): set function id
+            params(dict): key/value pairs to be passed to the function
+        """
+        try:
+            # The 'token' parameter has to be first, and 'fun' second
+            # or the UPC firmware will return an error
+            params_str = ''.join([f'&{key}={value}' for (key,value) in params.items()])
+
+            async with await self._session.post(
+                f"http://{self.host}/xml/setter.xml",
+                data=f"token={self.token}&fun={function}{params_str}",
+                #data=params,
+                headers=self.headers,
+                allow_redirects=False,
+                timeout=10,
+            ) as response:
+
+                # If there is an error
+                if response.status != 200:
+                    _LOGGER.debug("Receive HTTP code %d", response.status)
+                    self.token = None
+                    print(response.status)
+                    print(response.content)
+                    raise exceptions.ConnectBoxError()
+
+                # Load data, store token for next request
+                self.token = response.cookies["sessionToken"].value
+                await response.text()
+                return True
 
         except (asyncio.TimeoutError, aiohttp.ClientError) as err:
             _LOGGER.error("Error received on %s: %s", function, err)

--- a/connect_box/__init__.py
+++ b/connect_box/__init__.py
@@ -151,7 +151,7 @@ class ConnectBox:
         raw = await self._async_ws_get_function(CMD_GET_IPV6_FILTER_RULE)
 
         try:
-            xml_root = element_tree.fromstring(raw)    
+            xml_root = element_tree.fromstring(raw)
             for instance in xml_root.iter("instance"):
                 self.ipv6_filters.append(
                     Ipv6FilterInstance(
@@ -175,7 +175,7 @@ class ConnectBox:
                 _parse_general_time(xml_root),
                 _parse_daily_time(xml_root)
             )
-    
+
         except (element_tree.ParseError, TypeError):
             _LOGGER.warning("Can't read IPv6 filter rules from %s", self.host)
             self.token = None
@@ -194,7 +194,7 @@ class ConnectBox:
         val_enabled = '*'.join([str(fs.enabled) for fs in filter_states.entries])
         val_del = '*'.join(['0' for fs in filter_states.entries])
         val_idd = '*'.join([str(fs.idd) for fs in filter_states.entries])
-    
+
         params = OrderedDict()
         params['act'] = 1
         params['dir'] = 0
@@ -215,9 +215,9 @@ class ConnectBox:
         params['dsIpRange'] = ''
         params['PortRange'] = ''
         params['TMode'] = self._ipv6_filters_time.TMode
-        if self._ipv6_filters_time.TMode == 1: 
+        if self._ipv6_filters_time.TMode == 1:
             params['TRule'] = self._ipv6_filters_time.XmlGeneralTime
-        elif self._ipv6_filters_time.TMode == 2: 
+        elif self._ipv6_filters_time.TMode == 2:
             params['TRule'] = self._ipv6_filters_time.XmlDailyTime
         else:
             params['TRule'] = 0
@@ -231,7 +231,7 @@ class ConnectBox:
 
         for st in states.entries:
             if st.idd == idd:
-                st.enabled = int(not(bool(st.enabled)))
+                st.enabled = int(not bool(st.enabled))
                 new_value = bool(st.enabled)
                 break
         if new_value is not None:
@@ -328,7 +328,7 @@ class ConnectBox:
         try:
             # The 'token' parameter has to be first, and 'fun' second
             # or the UPC firmware will return an error
-            params_str = ''.join([f'&{key}={value}' for (key,value) in params.items()])
+            params_str = ''.join([f'&{key}={value}' for (key, value) in params.items()])
 
             async with await self._session.post(
                 f"http://{self.host}/xml/setter.xml",

--- a/connect_box/data.py
+++ b/connect_box/data.py
@@ -1,6 +1,6 @@
 """Handle Data attributes."""
 from ipaddress import IPv4Address, IPv6Address, ip_address as convert_ip
-from typing import Union
+from typing import Union, Iterable
 
 import attr
 
@@ -46,3 +46,41 @@ class UpstreamChannel:
     t4Timeouts: int = attr.ib()
     channelType: str = attr.ib()
     messageType: int = attr.ib()
+
+
+@attr.s
+class Ipv6FilterInstance:
+    """An IPv6 filter rule instance."""
+
+    idd: int = attr.ib()
+    srcAddr: Union[IPv4Address, IPv6Address] = attr.ib(converter=convert_ip)
+    srcAddr: str = attr.ib()
+    srcPrefix: int = attr.ib()
+    dstAddr: str = attr.ib()
+    dstAddr: Union[IPv4Address, IPv6Address] = attr.ib(converter=convert_ip)
+    dstPrefix: int = attr.ib()
+    srcPortStart: int = attr.ib()
+    srcPortEnd: int = attr.ib()
+    dstPortStart: int = attr.ib()
+    dstPortEnd: int = attr.ib()
+    protocol: int = attr.ib()
+    allow: int = attr.ib()
+    enabled: int = attr.ib()
+
+@attr.s
+class FiltersTimeMode:
+    """Filters time setting."""
+    TMode: int = attr.ib()
+    XmlGeneralTime: str = attr.ib()
+    XmlDailyTime: str = attr.ib()
+
+@attr.s
+class FilterStatesList:
+    """A sequence of filter state instances."""
+    entries: Iterable = attr.ib()
+
+@attr.s
+class FilterState:
+    """A filter state instance."""
+    idd: int = attr.ib()
+    enabled: int = attr.ib()

--- a/connect_box/parsers.py
+++ b/connect_box/parsers.py
@@ -1,0 +1,29 @@
+def _parse_general_time(xml_root):
+    """Convert <GeneralTime> to"""
+
+    el = xml_root.find("GeneralTime/time")
+    if el is not None:
+        return ','.join([str(int(h)*60+int(m)) for t in el.text.split('-') for h, m in [t.split(':')]])
+    else:
+        return None
+
+def _parse_daily_time(xml_root):
+    """Convert contents of <DailyTime> to decimal mask"""
+    mask = [[0 for h in range(24)] for d in range(7)]
+    for instance in xml_root.findall("DailyTime/time_instance"):
+        day = int(instance.find('daily').text) -1
+        s, e = instance.find('time').text.split('-')
+        s, e = int(s), int(e)+1
+        mask[day][s:e] = [1] * (e-s)
+
+    output = []
+    for daybin in mask:
+        daydec = 0
+        for bit in daybin:
+            daydec = (daydec  << 1) | bit
+        output.append(str(daydec))
+
+    if (output is not None and len(output)):
+        return ','.join(output)
+    else:
+        return None

--- a/example.py
+++ b/example.py
@@ -24,6 +24,17 @@ async def main():
         await client.async_get_devices()
         pprint(client.devices)
 
+        # Print IPv6 filter rules
+        # (IPv6 required)
+        await client.async_get_ipv6_filtering()
+        pprint(client.ipv6_filters)
+
+        # Toggle enable/disable on the first IPv6 filter rule
+        new_value = await client.async_toggle_ipv6_filter(1)
+        # Show the effect
+        await client.async_get_ipv6_filtering()
+        pprint(client.ipv6_filters)
+
         await client.async_close_session()
 
 

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ with open(os.path.join(here, "README.rst"), encoding="utf-8") as readme:
 
 setup(
     name="connect_box",
-    version="0.2.6",
+    version="0.2.7",
     description="Python client for interacting with Compal CH7465LG devices.",
     long_description=long_description,
     long_description_content_type="text/x-rst",


### PR DESCRIPTION
I've tried implementing toggling of (IPv6) filter rules I mentioned in #14. As I byproduct, you can also list these rules. 

As toggling requires usage of `setter.xml` and every "toggle" post request needs to supply all the filter rules as well as filter time settings, I needed to add quite a lot. I tried not deviating from your approach. For consistency I also renamed `_async_ws_function` to `_async_ws_get_function` so that it is differentiated from `_async_ws_set_function` I added. 

From the interface perspective, there are two new two methods and one property added:
- `async_get_ipv6_filtering()`
- `async_toggle_ipv6_filter(idd)`
- `ipv6_filters`

It works for me (UPC/Unitymedia in Germany). I only added IPv6 as that's what I have and need myself. I assume IPv4 could follow a similar path.

Hope this is acceptable to you, @fabaff .  